### PR TITLE
Complete the request if there is an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -316,6 +316,10 @@ function HttpRequest(options) {
 			}
 		};
 	}
+
+	if ('onerror' in xhr && !xhr.onreadystatechange) {
+		xhr.onerror = onLoad;
+	}
 }
 
 module.exports = HttpRequest;


### PR DESCRIPTION
If the server is unreachable, `onerror` is called.
It should call the `onLoad` function to complete the request.
